### PR TITLE
fix(#12): fix to show whole time about media.

### DIFF
--- a/src/main/scala/jp/ed/nnn/movieplayer/Main.scala
+++ b/src/main/scala/jp/ed/nnn/movieplayer/Main.scala
@@ -96,12 +96,18 @@ class Main extends Application {
             val filePath = f.getAbsolutePath
             val fileName = f.getName
             val media = new Media(f.toURI.toString)
-            val time = formatTime(media.getDuration)
-            val movie = Movie(System.currentTimeMillis(), fileName, time, filePath, media)
-            while (movies.contains(movie)) {
-              movie.setId(movie.getId + 1L)
-            }
-            movies.add(movie)
+            val player = new MediaPlayer(media)
+            player.setOnReady(new Runnable {
+              override def run(): Unit = {
+                val time = formatTime(media.getDuration)
+                val movie = Movie(System.currentTimeMillis(), fileName, time, filePath, media)
+                while (movies.contains(movie)) {
+                  movie.setId(movie.getId + 1L)
+                }
+                movies.add(movie)
+                player.dispose()
+              }
+            })
           }
         }
         event.consume()


### PR DESCRIPTION
ファイルの再生時間を正しく表示
close #12 