### PR TITLE
feat: fix a few bag and refactoring.

### DIFF
--- a/src/main/scala/jp/ed/nnn/movieplayer/Main.scala
+++ b/src/main/scala/jp/ed/nnn/movieplayer/Main.scala
@@ -66,15 +66,15 @@ class Main extends Application {
 
     tableView.getColumns.setAll(fileNameColumn, timeColumn, deleteActionColumn)
 
-    val toolBar = ToolbarCreator.create(mediaView, tableView, timeLabel, primaryStage)
-
     val baseBorderPane = new BorderPane()
+    val scene = new Scene(baseBorderPane, mediaViewFitWidth + tableMinWidth, mediaViewFitHeight + toolBarMinHeight)
+    val toolBar = ToolbarCreator.create(mediaView, tableView, timeLabel, scene, primaryStage)
+
     baseBorderPane.setStyle("-fx-background-color: Black")
     baseBorderPane.setCenter(mediaView)
     baseBorderPane.setBottom(toolBar)
     baseBorderPane.setRight(tableView)
 
-    val scene = new Scene(baseBorderPane, mediaViewFitWidth + tableMinWidth, mediaViewFitHeight + toolBarMinHeight)
     scene.setFill(Color.BLACK)
     mediaView.fitWidthProperty().bind(scene.widthProperty().subtract(tableMinWidth))
     mediaView.fitHeightProperty().bind(scene.heightProperty().subtract(toolBarMinHeight))

--- a/src/main/scala/jp/ed/nnn/movieplayer/ToolbarButtonCreator.scala
+++ b/src/main/scala/jp/ed/nnn/movieplayer/ToolbarButtonCreator.scala
@@ -1,0 +1,30 @@
+package jp.ed.nnn.movieplayer
+
+import javafx.event.{ActionEvent, EventHandler}
+import javafx.scene.control.Button
+import javafx.scene.image.{Image, ImageView}
+import javafx.scene.input.MouseEvent
+import jp.ed.nnn.movieplayer.ToolbarCreator.getClass
+
+object ToolbarButtonCreator {
+
+  def createButton(imagePath: String, eventHandler: EventHandler[ActionEvent]): Button = {
+    val buttonImage = new Image(getClass.getResourceAsStream(imagePath))
+    val button = new Button()
+    button.setGraphic(new ImageView(buttonImage))
+    button.setStyle("-fx-background-color: Black")
+    button.setOnAction(eventHandler)
+    button.addEventHandler(MouseEvent.MOUSE_ENTERED, new EventHandler[MouseEvent] {
+      override def handle(event: MouseEvent): Unit = {
+        button.setStyle("-fx-body-color: Black")
+      }
+    })
+    button.addEventHandler(MouseEvent.MOUSE_EXITED, new EventHandler[MouseEvent] {
+      override def handle(event: MouseEvent): Unit = {
+        button.setStyle("-fx-background-color: Black")
+      }
+    })
+    button
+  }
+
+}

--- a/src/main/scala/jp/ed/nnn/movieplayer/ToolbarCreator.scala
+++ b/src/main/scala/jp/ed/nnn/movieplayer/ToolbarCreator.scala
@@ -1,20 +1,22 @@
 package jp.ed.nnn.movieplayer
 
+import java.lang
+
+import javafx.beans.value.{ChangeListener, ObservableValue}
 import javafx.event.{ActionEvent, EventHandler}
 import javafx.geometry.Pos
-import javafx.scene.control.{Button, Label, TableView}
-import javafx.scene.image.{Image, ImageView}
-import javafx.scene.input.MouseEvent
+import javafx.scene.Scene
+import javafx.scene.control.{Label, TableView}
 import javafx.scene.layout.HBox
 import javafx.scene.media.MediaView
 import javafx.stage.Stage
 import javafx.util.Duration
-
 import jp.ed.nnn.movieplayer.SizeConstants._
+import jp.ed.nnn.movieplayer.ToolbarButtonCreator.createButton
 
 object ToolbarCreator {
 
-  def create(mediaView: MediaView, tableView: TableView[Movie], timeLabel: Label, primaryStage: Stage): HBox = {
+  def create(mediaView: MediaView, tableView: TableView[Movie], timeLabel: Label, scene: Scene, primaryStage: Stage): HBox = {
     val toolBar = new HBox()
     toolBar.setMinHeight(toolBarMinHeight)
     toolBar.setAlignment(Pos.CENTER)
@@ -57,13 +59,13 @@ object ToolbarCreator {
 
     // forward button
     val forwardButton = createButton("images/forward.png", new EventHandler[ActionEvent] {
-      override def handle(event: ActionEvent): Unit = {
+      override def handle(event: ActionEvent): Unit =
         if (mediaView.getMediaPlayer != null) {
-          mediaView.getMediaPlayer.seek(
-            mediaView.getMediaPlayer.getCurrentTime.add(new Duration(10000))
-          )
+          val player = mediaView.getMediaPlayer
+          if (player.getTotalDuration.greaterThan(player.getCurrentTime.add(new Duration(10000)))) {
+            player.seek(player.getCurrentTime.add(new Duration(10000)))
+          }
         }
-      }
     })
 
     // last Button
@@ -76,29 +78,26 @@ object ToolbarCreator {
 
     // fullscreen Button
     val fullscreenButton = createButton("images/fullscreen.png", new EventHandler[ActionEvent] {
-      override def handle(event: ActionEvent): Unit =
+      override def handle(event: ActionEvent): Unit = {
         primaryStage.setFullScreen(true)
+        mediaView.fitHeightProperty().unbind()
+        mediaView.fitHeightProperty().bind(scene.heightProperty())
+        mediaView.fitWidthProperty().unbind()
+        mediaView.fitWidthProperty().bind(scene.widthProperty())
+      }
+    })
+    primaryStage.fullScreenProperty().addListener(new ChangeListener[lang.Boolean] {
+      override def changed(observableValue: ObservableValue[_ <: lang.Boolean], oldValue: lang.Boolean, newValue: lang.Boolean): Unit =
+        if (!newValue) {
+          mediaView.fitHeightProperty().unbind()
+          mediaView.fitWidthProperty().unbind()
+          mediaView.fitHeightProperty().bind(scene.heightProperty().subtract(toolBarMinHeight))
+          mediaView.fitWidthProperty().bind(scene.widthProperty().subtract(tableMinWidth))
+        }
     })
 
     toolBar.getChildren.addAll(firstButton, backButton, playButton, pauseButton, forwardButton, lastButton, fullscreenButton, timeLabel)
+    toolBar
   }
 
-  private[this] def createButton(imagePath: String, eventHandler: EventHandler[ActionEvent]): Button = {
-    val buttonImage = new Image(getClass.getResourceAsStream(imagePath))
-    val button = new Button()
-    button.setGraphic(new ImageView(buttonImage))
-    button.setStyle("-fx-background-color: Black")
-    button.setOnAction(eventHandler)
-    button.addEventHandler(MouseEvent.MOUSE_ENTERED, new EventHandler[MouseEvent] {
-      override def handle(event: MouseEvent): Unit = {
-        button.setStyle("-fx-body-color: Black")
-      }
-    })
-    button.addEventHandler(MouseEvent.MOUSE_EXITED, new EventHandler[MouseEvent] {
-      override def handle(event: MouseEvent): Unit = {
-        button.setStyle("-fx-background-color: Black")
-      }
-    })
-    button
-  }
 }


### PR DESCRIPTION
以下いくつか対応
・ToolBarCreater.scalaのボタン生成処理をToolBarButtonCreater.scalaとして抽出し、リファクタリング
・早送りボタンを押下したとき、総再生時間を超えてしまったときに動画が停止してしまう不具合を修正
　（早送りする時間と現在の再生時間の合計が総再生時間より短い場合に、早送りができるよう修正）
・フルスクリーンボタン押下時に一覧まで表示されてしまっていたものを、一覧非表示になるよう修正